### PR TITLE
Convert fitbit-node to OAuth 2.0 authentication

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,17 +1,17 @@
 var express = require("express"),
     app = express();
 
-var FitbitApiClient = require("./fitbit-api-client"),
+var FitbitApiClient = require("fitbit-node"),
     client = new FitbitApiClient("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET");
 
 app.get("/authorize", function (req, res) {
-    res.redirect(client.getAuthorizeUrl('activity heartrate location nutrition profile settings sleep social weight', 'YOUR_REDIRECT_URL'));
+    res.redirect(client.getAuthorizeUrl('activity heartrate location nutrition profile settings sleep social weight', 'YOUR_CALLBACK_URL'));
 });
 
 app.get("/callback", function (req, res) {
-    client.getAccessToken(req.query.code, 'YOUR_REDIRECT_URL').then(function (result) {
-        client.get("/profile.json", result.access_token).then(function (result) {
-            res.send(result);
+    client.getAccessToken(req.query.code, 'YOUR_CALLBACK_URL').then(function (result) {
+        client.get("/profile.json", result.access_token).then(function (results) {
+            res.send(results[0]);
         });
     }).catch(function (error) {
         res.send(error);

--- a/example.js
+++ b/example.js
@@ -1,37 +1,21 @@
 var express = require("express"),
-	app = express();
+    app = express();
 
-var FitbitApiClient = require("fitbit-node"),
-	client = new FitbitApiClient("YOUR_CONSUMER_KEY", "YOUR_CONSUMER_SECRET");
-
-var requestTokenSecrets = {};
+var FitbitApiClient = require("./fitbit-api-client"),
+    client = new FitbitApiClient("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET");
 
 app.get("/authorize", function (req, res) {
-	client.getRequestToken().then(function (results) {
-		var token = results[0],
-			secret = results[1];
-		requestTokenSecrets[token] = secret;
-		res.redirect("http://www.fitbit.com/oauth/authorize?oauth_token=" + token);
-	}, function (error) {
-		res.send(error);
-	});
+    res.redirect(client.getAuthorizeUrl('activity heartrate location nutrition profile settings sleep social weight', 'YOUR_REDIRECT_URL'));
 });
 
-app.get("YOUR_CALLBACK_URL", function (req, res) {
-	var token = req.query.oauth_token,
-		secret = requestTokenSecrets[token],
-		verifier = req.query.oauth_verifier;
-	client.getAccessToken(token, secret, verifier).then(function (results) {
-		var accessToken = results[0],
-			accessTokenSecret = results[1],
-			userId = results[2].encoded_user_id;
-		return client.get("/profile.json", accessToken, accessTokenSecret).then(function (results) {
-			var response = results[0];
-			res.send(response);
-		});
-	}, function (error) {
-		res.send(error);
-	});
+app.get("/callback", function (req, res) {
+    client.getAccessToken(req.query.code, 'YOUR_REDIRECT_URL').then(function (result) {
+        client.get("/profile.json", result.access_token).then(function (result) {
+            res.send(result);
+        });
+    }).catch(function (error) {
+        res.send(error);
+    });
 });
 
 app.listen(3000);

--- a/fitbit-api-client.js
+++ b/fitbit-api-client.js
@@ -38,14 +38,20 @@ FitbitApiClient.prototype = {
         return deferred.promise;
     },
     
-    refreshAccesstoken: function (token) {
+    refreshAccesstoken: function (accessToken, refreshToken) {
         var deferred = Q.defer();
+          
+        var token = this.oauth2.accessToken.create({
+            access_token: accessToken,
+            refresh_token: refreshToken,
+            expires_in: -1
+        });
           
         token.refresh(function (error, result) {
             if (error) {
                 deferred.reject(error);
             } else {
-                deferred.resolve(result);
+                deferred.resolve(result.token);
             }
         });
         

--- a/fitbit-api-client.js
+++ b/fitbit-api-client.js
@@ -1,52 +1,146 @@
-var OAuth = require("oauth").OAuth,
-	Promise = require("bluebird");
+var OAuth2 = require('simple-oauth2'),
+    Q = require('q'),
+    Request = require('request');
 
-function FitbitApiClient(consumerKey, consumerSecret) {
-	this.oauth = new OAuth(
-		"https://api.fitbit.com/oauth/request_token",
-		"https://api.fitbit.com/oauth/access_token",
-		consumerKey,
-		consumerSecret,
-		"1.0",
-		null,
-		"HMAC-SHA1"
-	);
+function FitbitApiClient(clientID, clientSecret) {
+    this.oauth2 = OAuth2({
+        clientID: clientID,
+        clientSecret: clientSecret,
+        site: 'https://api.fitbit.com/', 
+        authorizationPath: 'oauth2/authorize',
+        tokenPath: 'oauth2/token',
+        useBasicAuthorizationHeader: true
+    });
 }
 
 FitbitApiClient.prototype = {
-	getRequestToken: function () {
-		var getRequestToken = Promise.promisify(this.oauth.getOAuthRequestToken, this.oauth);
-		return getRequestToken();
-	},
+    getAuthorizeUrl: function (scope, redirectUrl) {
+        return this.oauth2.authCode.authorizeURL({
+            scope: scope,
+            redirect_uri: redirectUrl
+        }).replace('api', 'www');
+    },
 
-	getAccessToken: function (requestToken, requestTokenSecret, verifier) {
-		var getAccessToken = Promise.promisify(this.oauth.getOAuthAccessToken, this.oauth);
-		return getAccessToken(requestToken, requestTokenSecret, verifier);
-	},
-	
-	get: function (path, accessToken, accessTokenSecret, userId) {
-		var getResource = Promise.promisify(this.oauth.get, this.oauth);
-		return getResource(getUrl(path, userId), accessToken, accessTokenSecret);
-	},
+    getAccessToken: function (code, redirectUrl) {
+        var deferred = Q.defer();
+          
+        this.oauth2.authCode.getToken({
+            code: code,
+            redirect_uri: redirectUrl
+        }, function (error, result) {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                deferred.resolve(result);
+            }
+        });
+        
+        return deferred.promise;
+    },
+    
+    refreshAccesstoken: function (token) {
+        var deferred = Q.defer();
+          
+        token.refresh(function (error, result) {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                deferred.resolve(result);
+            }
+        });
+        
+        return deferred.promise;
+    },
+    
+    get: function (path, accessToken, userId) {
+        var deferred = Q.defer();
+        
+        Request({
+            url: getUrl(path, userId), 
+            method: 'GET',
+            headers: {
+                Authorization: 'Bearer ' + accessToken
+            },
+            json: true
+        }, function(error, response, body) {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                deferred.resolve(response);
+            }
+        });
+        
+        return deferred.promise;
+    },
 
-	post: function (path, accessToken, accessTokenSecret, data, userId) {
-		var postResource = Promise.promisify(this.oauth.post, this.oauth);
-		return postResource(getUrl(path, userId), accessToken, accessTokenSecret, data);
-	},
+    post: function (path, accessToken, data, userId) {
+        var deferred = Q.defer();
+        
+        Request({
+            url: getUrl(path, userId), 
+            method: 'POST',
+            headers: {
+                Authorization: 'Bearer ' + accessToken
+            },
+            json: true,
+            body: data
+        }, function(error, response, body) {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                deferred.resolve(response);
+            }
+        });
+        
+        return deferred.promise;
+    },
 
-	put: function (path, accessToken, accessTokenSecret, data, userId) {
-		var putResource = Promise.promisify(this.oauth.put, this.oauth);
-		return putResource(getUrl(path, userId), accessToken, accessTokenSecret, data);
-	},
+    put: function (path, accessToken, data, userId) {
+        var deferred = Q.defer();
+        
+        Request({
+            url: getUrl(path, userId), 
+            method: 'PUT',
+            headers: {
+                Authorization: 'Bearer ' + accessToken
+            },
+            json: true,
+            body: data
+        }, function(error, response, body) {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                deferred.resolve(response);
+            }
+        });
+        
+         return deferred.promise;
+    },
 
-	delete: function (path, accessToken, accessTokenSecret, userId) {
-		var deleteResource = Promise.promisify(this.oauth.delete, this.oauth);
-		return deleteResource(getUrl(path, userId), accessToken, accessTokenSecret);
-	}
+    delete: function (path, accessToken, userId) {
+        var deferred = Q.defer();
+        
+        Request({
+            url: getUrl(path, userId), 
+            method: 'DELETE',
+            headers: {
+                Authorization: 'Bearer ' + accessToken
+            },
+            json: true
+        }, function(error, response, body) {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                deferred.resolve(response);
+            }
+        });
+        
+        return deferred.promise;
+    }
 };
 
 function getUrl(path, userId) {
-	return url = "https://api.fitbit.com/1/user/" + (userId || "-") + path;
+    return url = 'https://api.fitbit.com/1/user/' + (userId || '-') + path;
 }
 
 module.exports = FitbitApiClient;

--- a/fitbit-api-client.js
+++ b/fitbit-api-client.js
@@ -66,7 +66,10 @@ FitbitApiClient.prototype = {
             if (error) {
                 deferred.reject(error);
             } else {
-                deferred.resolve(response);
+                deferred.resolve([
+                    body,
+                    response
+                ]);
             }
         });
         
@@ -88,7 +91,10 @@ FitbitApiClient.prototype = {
             if (error) {
                 deferred.reject(error);
             } else {
-                deferred.resolve(response);
+                deferred.resolve([
+                    body,
+                    response
+                ]);
             }
         });
         
@@ -110,7 +116,10 @@ FitbitApiClient.prototype = {
             if (error) {
                 deferred.reject(error);
             } else {
-                deferred.resolve(response);
+                deferred.resolve([
+                    body,
+                    response
+                ]);
             }
         });
         
@@ -131,7 +140,10 @@ FitbitApiClient.prototype = {
             if (error) {
                 deferred.reject(error);
             } else {
-                deferred.resolve(response);
+                deferred.resolve([
+                    body,
+                    response
+                ]);
             }
         });
         

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "url": "https://github.com/lukasolson/fitbit-node/issues"
   },
   "dependencies": {
-    "simple-oauth2": "^0.4.0",
+    "simple-oauth2": "^0.5.1",
     "q": "^1.4.1",
-    "request": "^2.67.0"
+    "request": "^2.69.0"
   },
   "devDependencies": {
-    "express": "^4.13.3"
+    "express": "^4.13.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fitbit-node",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A Fitbit API client library written in Node.js.",
   "main": "fitbit-api-client.js",
   "scripts": {
@@ -15,15 +15,16 @@
     "Node"
   ],
   "author": "Lukas Olson <olson.lukas@gmail.com>",
-  "license": "BSD",
+  "license": "ISC",
   "bugs": {
     "url": "https://github.com/lukasolson/fitbit-node/issues"
   },
   "dependencies": {
-    "bluebird": "^2.9.34",
-    "oauth": "^0.9.13"
+    "simple-oauth2": "^0.4.0",
+    "q": "^1.4.1",
+    "request": "^2.67.0"
   },
   "devDependencies": {
-    "express": "^4.13.1"
+    "express": "^4.13.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -8,23 +8,26 @@ An API client library written for Fitbit in NodeJS.
 
 ## API
 
-#### `new FitbitApiClient(consumerKey, consumerSecret)`
-Constructor. Use the `consumerKey` and `consumerSecret` provided to you when you registered your app on [dev.fitbit.com](http://dev.fitbit.com/).
+#### `new FitbitApiClient(clientID, clientSecret)`
+Constructor. Use the `clientID` and `clientSecret` provided to you when you registered your app on [dev.fitbit.com](http://dev.fitbit.com/).
 
-#### `getRequestToken()`
-Get a request token. This is the first step of the OAuth flow. Returns a promise. When this promise is resolved with a request token, forward the user to the Fitbit site (e.g., http://www.fitbit.com/oauth/authorize?oauth_token=<requestToken>) for authentication. (You can substitute "authenticate" instead of "authorize" in the URL if you do not wish to forward to the Fitbit site for authentication next time you request an access token.)
+#### `getAuthorizeUrl(scope, redirectUrl)`
+Construct the authorization URL. This is the first step of the OAuth 2.0 flow. Returns a string. When this string containing the authorization URL on the Fitbit site is returned, redirect the user to that URL for authorization. The `scope` (a string of space-delimitted scope values you wish to obtain authorization for) and the `redirectUrl` (a string for the URL where you want Fitbit to redirect the user after authorization) are required. See the [Scope](https://dev.fitbit.com/docs/oauth2/#scope) section in Fitbit's API documentation for more details about possible scope values.
 
-#### `getAccessToken(requestToken, requestTokenSecret, verifier)`
-After the user authorizes with Fitbit, he/she will be forwarded to the URL you specify in your Fitbit API application settings, and the `requestToken` and `verifier` will be in the URL. Use these, along with the `requestTokenSecret` you received above to request an access token in order to make API calls. Returns a promise.
+#### `getAccessToken(code, redirectUrl)`
+After the user authorizes with Fitbit, he/she will be forwarded to the `redirectUrl` you specified when calling `getAuthorizationUrl()`, and the `code` will be present in the URL. Use this to exchange the authorization code for an access token in order to make API calls. Returns a promise.
 
-#### `get(url, accessToken, accessTokenSecret, [userId])`
+#### `refreshAccesstoken(refreshToken)`
+Refresh the user's access token, in the event that it has expired. The `refreshToken` would have been returned as `refresh_token` alongside the `access_token` by the `getAccessToken()` method. Returns a promise.
+
+#### `get(path, accessToken, [userId])`
 Make a GET API call to the Fitbit servers. (See [example.js](https://github.com/lukasolson/fitbit-node/blob/master/example.js) for an example.) Returns a promise.
 
-#### `post(url, accessToken, accessTokenSecret, data, [userId])`
+#### `post(path, accessToken, data, [userId])`
 Make a POST API call to the Fitbit servers. Returns a promise.
 
-#### `put(url, accessToken, accessTokenSecret, data, [userId])`
+#### `put(path, accessToken, data, [userId])`
 Make a PUT API call to the Fitbit servers. Returns a promise.
 
-#### `delete(url, accessToken, accessTokenSecret, [userId])`
+#### `delete(path, accessToken, [userId])`
 Make a DELETE API call to the Fitbit servers. Returns a promise.


### PR DESCRIPTION
Fitbit is deprecating OAuth 1.0a support on April 12, 2016. A one hour blackout test will be performed on March 14, 2016. During the test, all OAuth 1.0a requests will fail. Users should upgrade their applications to OAuth 2.0 by March 14th and use the blackout test as an opportunity to verify no part of their applications still use OAuth 1.0a.

More information is available here: https://dev.fitbit.com/docs/oauth2/#oauth-1-0a-deprecated

A couple of highlights on the changes below:
-  I switched from the `oauth` library to the `simple-oauth2` library as the former was incompatible with the Fitbit API. While `oauth` does support the OAuth 2.0 specification, it does not implement the recommendation in Section 2.3.1 of RFC 6479 which Fitbit's [Authorization Header](https://dev.fitbit.com/docs/oauth2/#authorization-header) uses.
- I switched back from `bluebird` to `q` for promises as it provided more control over promise resolution.
- I converted the `license` property in `package.json` from `BSD` to `ISC` to match the valid SPDX license expression for the BSD license.
- Bumped the `version` property in `package.json` to `2.0.0` so as not to break any clients currently using this library. However, these clients will need to upgrade to the latest in order to avoid the OAuth 1.0a deprecation. Migration guide available here: https://dev.fitbit.com/docs/oauth2/#migrating-from-oauth-1-0a
- These changes will address Issue #3 
