### PR TITLE
Use `form` for `PUT` and `POST`

### DIFF
--- a/fitbit-api-client.js
+++ b/fitbit-api-client.js
@@ -94,7 +94,7 @@ FitbitApiClient.prototype = {
                 Authorization: 'Bearer ' + accessToken
             },
             json: true,
-            body: data
+            form: data
         }, function(error, response, body) {
             if (error) {
                 deferred.reject(error);
@@ -119,7 +119,7 @@ FitbitApiClient.prototype = {
                 Authorization: 'Bearer ' + accessToken
             },
             json: true,
-            body: data
+            form: data
         }, function(error, response, body) {
             if (error) {
                 deferred.reject(error);


### PR DESCRIPTION
Prior to this patch, the Fitbit API would complain when attempting to use the `.post()` method to accept a friend request.

``` js
Fitbit.post("/friends/invitations/#{friend.user.encodedId}.json", accessToken, {accept: true})
```

Without patch:

```
[Tue Oct 11 2016 22:46:46 GMT-0500 (CDT)] DEBUG { errors: 
   [ { errorType: 'validation',
       fieldName: 'accept',
       message: 'Accept should be provided.' } ] }
```

With patch:

```
[Tue Oct 11 2016 22:41:42 GMT-0500 (CDT)] DEBUG { friends: [ { dateTime: '2016-10-11T20:41:41.256-07:00', userId: '24M3J7' } ] }
```

Not sure what's happening, but it appears that the implementation of the `request` library has an error.
