### PR TITLE
allow custom HTTP headers to be sent with each HTTP verb function

### DIFF
--- a/fitbit-api-client.js
+++ b/fitbit-api-client.js
@@ -61,7 +61,6 @@ FitbitApiClient.prototype = {
         return deferred.promise;
     },
 
-
     revokeAccessToken: function (accessToken) {
 
         var deferred = Q.defer();
@@ -83,30 +82,14 @@ FitbitApiClient.prototype = {
         return deferred.promise;
     },
 
-    addSubscription: function (accessToken, collectionPath, subscriptionId, subscriberId) {
-      var extraHeaders = null;
-      if (subscriberId) {
-        extraHeaders = { 'X-Fitbit-Subscriber-Id': subscriberId };
-      }
-
-      var path = "/" +
-        encodeURIComponent(collectionPath) +
-        "/apiSubscriptions/" +
-        encodeURIComponent(subscriptionId) +
-        ".json";
-
-      return this.post(path, accessToken, null, null, extraHeaders);
-    },
-
-    get: function (path, accessToken, userId) {
+    // extraHeaders is optional
+    get: function (path, accessToken, userId, extraHeaders) {
         var deferred = Q.defer();
 
         Request({
             url: getUrl(path, userId),
             method: 'GET',
-            headers: {
-                Authorization: 'Bearer ' + accessToken
-            },
+            headers: mergeHeaders(accessToken, extraHeaders),
             json: true
         }, function(error, response, body) {
             if (error) {
@@ -122,23 +105,14 @@ FitbitApiClient.prototype = {
         return deferred.promise;
     },
 
+    // extraHeaders is optional
     post: function (path, accessToken, data, userId, extraHeaders) {
         var deferred = Q.defer();
-
-        var headers = {
-            Authorization: 'Bearer ' + accessToken
-        };
-
-        if (extraHeaders) {
-          for (var attrname in extraHeaders) {
-            headers[attrname] = extraHeaders[attrname];
-          }
-        }
 
         Request({
             url: getUrl(path, userId),
             method: 'POST',
-            headers: headers,
+            headers: mergeHeaders(accessToken, extraHeaders),
             json: true,
             form: data
         }, function(error, response, body) {
@@ -155,15 +129,14 @@ FitbitApiClient.prototype = {
         return deferred.promise;
     },
 
-    put: function (path, accessToken, data, userId) {
+    // extraHeaders is optional
+    put: function (path, accessToken, data, userId, extraHeaders) {
         var deferred = Q.defer();
 
         Request({
             url: getUrl(path, userId),
             method: 'PUT',
-            headers: {
-                Authorization: 'Bearer ' + accessToken
-            },
+            headers: mergeHeaders(accessToken, extraHeaders),
             json: true,
             form: data
         }, function(error, response, body) {
@@ -180,15 +153,14 @@ FitbitApiClient.prototype = {
          return deferred.promise;
     },
 
-    delete: function (path, accessToken, userId) {
+    // extraHeaders is optional
+    delete: function (path, accessToken, userId, extraHeaders) {
         var deferred = Q.defer();
 
         Request({
             url: getUrl(path, userId),
             method: 'DELETE',
-            headers: {
-                Authorization: 'Bearer ' + accessToken
-            },
+            headers: mergeHeaders(accessToken, extraHeaders),
             json: true
         }, function(error, response, body) {
             if (error) {
@@ -207,6 +179,20 @@ FitbitApiClient.prototype = {
 
 function getUrl(path, userId) {
     return path = 'https://api.fitbit.com/1/user/' + (userId || '-') + path;
+}
+
+function mergeHeaders(accessToken, extraHeaders) {
+    var headers = {
+        Authorization: 'Bearer ' + accessToken
+    };
+
+    if (typeof extraHeaders !== "undefined" && extraHeaders) {
+      for (var attrname in extraHeaders) {
+        headers[attrname] = extraHeaders[attrname];
+      }
+    }
+
+    return headers;
 }
 
 module.exports = FitbitApiClient;

--- a/fitbit-api-client.js
+++ b/fitbit-api-client.js
@@ -62,7 +62,7 @@ FitbitApiClient.prototype = {
     },
 
 
-    revokeAccessToken: function (accessToken, reportInvalidToken) {
+    revokeAccessToken: function (accessToken) {
 
         var deferred = Q.defer();
 

--- a/fitbit-api-client.js
+++ b/fitbit-api-client.js
@@ -83,6 +83,20 @@ FitbitApiClient.prototype = {
         return deferred.promise;
     },
 
+    addSubscription: function (accessToken, collectionPath, subscriptionId, subscriberId) {
+      var extraHeaders = null;
+      if (subscriberId) {
+        extraHeaders = { 'X-Fitbit-Subscriber-Id': subscriberId };
+      }
+
+      var path = "/" +
+        encodeURIComponent(collectionPath) +
+        "/apiSubscriptions/" +
+        encodeURIComponent(subscriptionId) +
+        ".json";
+
+      return this.post(path, accessToken, null, null, extraHeaders);
+    },
 
     get: function (path, accessToken, userId) {
         var deferred = Q.defer();
@@ -108,15 +122,23 @@ FitbitApiClient.prototype = {
         return deferred.promise;
     },
 
-    post: function (path, accessToken, data, userId) {
+    post: function (path, accessToken, data, userId, extraHeaders) {
         var deferred = Q.defer();
+
+        var headers = {
+            Authorization: 'Bearer ' + accessToken
+        };
+
+        if (extraHeaders) {
+          for (var attrname in extraHeaders) {
+            headers[attrname] = extraHeaders[attrname];
+          }
+        }
 
         Request({
             url: getUrl(path, userId),
             method: 'POST',
-            headers: {
-                Authorization: 'Bearer ' + accessToken
-            },
+            headers: headers,
             json: true,
             form: data
         }, function(error, response, body) {

--- a/fitbit-api-client.js
+++ b/fitbit-api-client.js
@@ -9,6 +9,7 @@ function FitbitApiClient(clientID, clientSecret) {
         site: 'https://api.fitbit.com/',
         authorizationPath: 'oauth2/authorize',
         tokenPath: 'oauth2/token',
+        revocationPath: 'oauth2/revoke',
         useBasicAuthorizationHeader: true
     });
 }
@@ -59,6 +60,29 @@ FitbitApiClient.prototype = {
 
         return deferred.promise;
     },
+
+
+    revokeAccessToken: function (accessToken, reportInvalidToken) {
+
+        var deferred = Q.defer();
+
+        var token = this.oauth2.accessToken.create({
+            access_token: accessToken,
+            refresh_token: '',
+            expires_in: ''
+        });
+
+        token.revoke('access_token', function (error, result) {
+            if (error) {
+                deferred.reject(error);
+            } else {
+                deferred.resolve(result);
+            }
+        });
+
+        return deferred.promise;
+    },
+
 
     get: function (path, accessToken, userId) {
         var deferred = Q.defer();

--- a/readme.md
+++ b/readme.md
@@ -20,14 +20,20 @@ After the user authorizes your application with Fitbit, they will be forwarded t
 #### `refreshAccesstoken(accessToken, refreshToken, [expiresIn])`
 Refresh the user's access token, in the event that it has expired. The `accessToken` and `refreshToken` (returned as `refresh_token` alongside the `access_token` by the `getAccessToken()` method) are required. The `expiresIn` parameter specifies the new desired access token lifetime in seconds. Returns a promise.
 
-#### `get(path, accessToken, [userId])`
+#### `get(path, accessToken, [userId], [extraHeaders])`
 Make a GET API call to the Fitbit servers. (See [example.js](https://github.com/lukasolson/fitbit-node/blob/master/example.js) for an example.) Returns a promise.
 
-#### `post(path, accessToken, data, [userId])`
+#### `post(path, accessToken, data, [userId], [extraHeaders])`
 Make a POST API call to the Fitbit servers. Returns a promise.
 
-#### `put(path, accessToken, data, [userId])`
+#### `put(path, accessToken, data, [userId], [extraHeaders])`
 Make a PUT API call to the Fitbit servers. Returns a promise.
 
-#### `delete(path, accessToken, [userId])`
+#### `delete(path, accessToken, [userId], [extraHeaders])`
 Make a DELETE API call to the Fitbit servers. Returns a promise.
+
+#### Custom HTTP Headers
+
+Some Fitbit API calls (such as [adding subscriptions](https://dev.fitbit.com/docs/subscriptions/#adding-a-subscription)) accept an optional HTTP header.  The `get`, `post`, `put`, and `delete` functions accept an optional parameter with an object with HTTP headers to handle these kind of calls (`extraHeaders` above).  The default `Authorization` header is merged with the provided parameter, if it exists.
+
+


### PR DESCRIPTION
Hi there,

What do you think about adding this implementation of the "add subscriber" API call?  

https://dev.fitbit.com/docs/subscriptions/#adding-a-subscription

It's a bit of a one off, because the API call takes an optional HTTP header, so I had to add an optional extra parameter to the `post` function, to allow the additional header.   Let me know your thoughts.

Thanks!

Alex

