### PR TITLE
Support 'prompt' and 'state' parameters to the client.getAuthorizeUrl method.

### DIFF
--- a/fitbit-api-client.js
+++ b/fitbit-api-client.js
@@ -15,10 +15,12 @@ function FitbitApiClient(clientID, clientSecret) {
 }
 
 FitbitApiClient.prototype = {
-    getAuthorizeUrl: function (scope, redirectUrl) {
+    getAuthorizeUrl: function (scope, redirectUrl, prompt, state) {
         return this.oauth2.authCode.authorizeURL({
             scope: scope,
-            redirect_uri: redirectUrl
+            redirect_uri: redirectUrl,
+            prompt: prompt, 
+            state: state
         }).replace('api', 'www');
     },
 

--- a/fitbit-api-client.js
+++ b/fitbit-api-client.js
@@ -39,7 +39,7 @@ FitbitApiClient.prototype = {
         return deferred.promise;
     },
 
-    refreshAccesstoken: function (accessToken, refreshToken, expiresIn) {
+    refreshAccessToken: function (accessToken, refreshToken, expiresIn) {
         if(expiresIn === undefined) expiresIn = -1;
 
         var deferred = Q.defer();

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Construct the authorization URL. This is the first step of the OAuth 2.0 flow. R
 #### `getAccessToken(code, redirectUrl)`
 After the user authorizes your application with Fitbit, they will be forwarded to the `redirectUrl` you specified when calling `getAuthorizationUrl()`, and the `code` will be present in the URL. Use this to exchange the authorization code for an access token in order to make API calls. Returns a promise.
 
-#### `refreshAccesstoken(accessToken, refreshToken, [expiresIn])`
+#### `refreshAccessToken(accessToken, refreshToken, [expiresIn])`
 Refresh the user's access token, in the event that it has expired. The `accessToken` and `refreshToken` (returned as `refresh_token` alongside the `access_token` by the `getAccessToken()` method) are required. The `expiresIn` parameter specifies the new desired access token lifetime in seconds. Returns a promise.
 
 #### `get(path, accessToken, [userId])`

--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,8 @@ An API client library for Fitbit written in Node.js.
 #### `new FitbitApiClient(clientID, clientSecret)`
 Constructor. Use the `clientID` and `clientSecret` provided to you when you registered your application on [dev.fitbit.com](http://dev.fitbit.com/).
 
-#### `getAuthorizeUrl(scope, redirectUrl)`
-Construct the authorization URL. This is the first step of the OAuth 2.0 flow. Returns a string. When this string containing the authorization URL on the Fitbit site is returned, redirect the user to that URL for authorization. The `scope` (a string of space-delimitted scope values you wish to obtain authorization for) and the `redirectUrl` (a string for the URL where you want Fitbit to redirect the user after authorization) are required. See the [Scope](https://dev.fitbit.com/docs/oauth2/#scope) section in Fitbit's API documentation for more details about possible scope values.
+#### `getAuthorizeUrl(scope, redirectUrl, [prompt], [state])`
+Construct the authorization URL. This is the first step of the OAuth 2.0 flow. Returns a string. When this string containing the authorization URL on the Fitbit site is returned, redirect the user to that URL for authorization. The `scope` (a string of space-delimitted scope values you wish to obtain authorization for) and the `redirectUrl` (a string for the URL where you want Fitbit to redirect the user after authorization) are required. See the [Scope](https://dev.fitbit.com/docs/oauth2/#scope) section in Fitbit's API documentation for more details about possible scope values. See the [Authorization Page](https://dev.fitbit.com/docs/oauth2/#authorization-page) section in Fitbit's API documentation for more details about possible `prompt` and `state` values. 
 
 #### `getAccessToken(code, redirectUrl)`
 After the user authorizes your application with Fitbit, they will be forwarded to the `redirectUrl` you specified when calling `getAuthorizationUrl()`, and the `code` will be present in the URL. Use this to exchange the authorization code for an access token in order to make API calls. Returns a promise.

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,9 @@ After the user authorizes your application with Fitbit, they will be forwarded t
 #### `refreshAccessToken(accessToken, refreshToken, [expiresIn])`
 Refresh the user's access token, in the event that it has expired. The `accessToken` and `refreshToken` (returned as `refresh_token` alongside the `access_token` by the `getAccessToken()` method) are required. The `expiresIn` parameter specifies the new desired access token lifetime in seconds. Returns a promise.
 
+#### `revokeAccessToken(accessToken)`
+Revoke the user's access token. The `accessToken` to be revoked is required. Returns a promise.
+
 #### `get(path, accessToken, [userId])`
 Make a GET API call to the Fitbit servers. (See [example.js](https://github.com/lukasolson/fitbit-node/blob/master/example.js) for an example.) Returns a promise.
 


### PR DESCRIPTION
Hi again, 

I added 'prompt' and 'state' parameters to the client.getAuthorizeUrl method and updated the documentation to reflect that.

Also, I was thinking that the argument list is getting a little long for this method.  I didn't want to diverge from the general style so far, but maybe the methods could be revised to accept an options object as the last parameter for optional arguments like 'prompt' and 'state'?

Cheers,
Alex